### PR TITLE
Add header tests

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const path = require('path');
+
+// This is a custom Jest transformer turning file imports into filenames.
+// http://facebook.github.io/jest/docs/tutorial-webpack.html
+
+module.exports = {
+  process(src, filename) {
+    return `module.exports = ${JSON.stringify(path.basename(filename))};`;
+  },
+};

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,16 @@
+module.exports = function (api) {
+  const presets = [
+    '@babel/preset-env',
+    '@babel/preset-react'
+  ];
+  const plugins = [
+    '@babel/plugin-transform-runtime',
+  ];
+
+  api.cache(false);
+
+  return {
+    presets,
+    plugins
+  };
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "webpack-dev-server",
     "lint": "eslint \"src/**/*.js\"",
     "build": "NODE_ENV=production webpack",
+    "test": "node_modules/.bin/jest",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
   },

--- a/src/components/header/header.test.js
+++ b/src/components/header/header.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Header } from './';
+import { mount } from 'enzyme';
+
+describe("Header", () => {
+  it("should contain an element with the class 'header'", () => {
+    const wrapper = mount(<Header />);
+    
+    expect(wrapper.find('.header').length).toEqual(1);
+  });
+  it("should contain a headline", () => {
+    const wrapper = mount(<Header />);
+    
+    expect(wrapper.find('h1').text()).toEqual("Spelling Study Buddy");
+  });
+});


### PR DESCRIPTION
**Summary**
- adjusted test setup:
  - added babel config
  - added file transformer for CSS imports
- added `test` script command
- added unit tests for header component

Resolves https://github.com/sesamechicken/spelling-buddy/issues/8