### PR TITLE
WordLoader Tests

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/components/wordLoader/index.js
+++ b/src/components/wordLoader/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Form, TextArea, Button, Icon } from 'semantic-ui-react';
 import actions from '../../redux/actions';
 import './wordLoader.css';
-class WordLoader extends React.Component {
+export class WordLoader extends React.Component {
   
   constructor(props){
     super(props);

--- a/src/components/wordLoader/wordLoader.test.js
+++ b/src/components/wordLoader/wordLoader.test.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { Icon, Button, TextArea } from "semantic-ui-react";
+
+import { WordLoader } from "./index";
+
+describe("renders an expected Form", () => {
+    /** The "shallow" container for Enzyme to use for our React DOM "parent" */
+    let container;
+
+    /** Render our WordLoader Component for inspection. */
+    beforeAll(() => { container = shallow(<WordLoader />); } );
+
+    test("Form has a text area", () => {
+        expect( container.containsMatchingElement(
+            <TextArea />
+        )).toBe(true);
+    });
+    test("Form has a load and clear button", () => {
+        expect( container.containsMatchingElement(
+            <Button><Icon /> Load</Button>
+        )).toBe(true);
+        expect( container.containsMatchingElement(
+            <Button><Icon /> Clear</Button>
+        )).toBe(true);
+    });
+});


### PR DESCRIPTION
Following along with momentum from FileLoader pull request (#14), wanted to get the framework build for WordLoader testing.  I've gotten a base framework in for that, marked with //TODO's for the things I have not yet implemented.

I am not sure what the continuous integration or other features of your Github.io site are or with automated pull requests, so I left the framework tests as //TODO items and did not mandate that they all fail() while they await implementation.

For tidiness: I did merge changes after your recent PR's, the only real difference i have is cleaning up where there was an extra script for test: jest in the NPM package file.

In WordLoader, to be able to import the module in the same way I did with FileLoader, I needed to add the "export" keyword to the class.

For the WordLoader tests, I have a simple test in place for the rendering of the widget, using Enzyme and Jest.  I haven't been able to master the process of requesting children of the React elements and inspecting them in more depth.  Other than that, I mostly set up the framework for individual tests of the methods, and of the behavior of the buttons (these are definitely duplications, so feel free to decide which one to keep)

Anyway, I think that will wrap up my work tonight, happy Halloween and happy Hacktoberfest!